### PR TITLE
Enhance ChatScreen with mushroom selection grid and image display

### DIFF
--- a/Screens/ChatScreen.jsx
+++ b/Screens/ChatScreen.jsx
@@ -11,6 +11,8 @@ import { Keyboard } from "react-native";
 import { Ionicons } from "@expo/vector-icons";
 import MushroomIcon from "../assets/chaticons/mushroomIcon.png"
 import ToxicityIndicator from "../Components/ToxicityIndicator";
+import mushroomPictureMap from "../Components/MushroomPictureMap.js";
+
 const ChatScreen = () => {
   const { user, setUser } = useContext(AuthContext); // Retrieve user information from AuthContext
   const [messages, setMessages] = useState([]); // Stores chat messages
@@ -176,7 +178,7 @@ const ChatScreen = () => {
       InteractionManager.runAfterInteractions(() => {
         setTimeout(() => {
           flatListRef.current?.scrollToOffset({ offset: 0, animated: true });
-        }, 100); 
+        }, 100);
       });
     });
     return () => {
@@ -509,18 +511,28 @@ const ChatScreen = () => {
                   <View style={styles.modalContent}>
                     <View style={{ flexDirection: 'row', alignItems: 'center', gap: 4, paddingBottom: 16, paddingTop: 16 }}>
                       <Text style={styles.modalTitle}>Select a Mushroom</Text>
-                      <Image source={MushroomIcon} style={{ width: 30, height: 30 }} />
+                      <Image source={MushroomIcon} style={{ width: 30, height: 30, resizeMode: 'contain' }} />
                     </View>
+
                     <FlatList
                       data={foundMushrooms}
                       keyExtractor={(item) => item.m_id.toString()}
+                      numColumns={2}
                       renderItem={({ item }) => (
-                        <TouchableOpacity onPress={() => {
-                          fetchFindingsForMushroom(item.m_id);
-                          setActiveModal(false);
-                        }}>
-                          <Text style={styles.mushroomName}>{item.cmname}</Text>
-                          <View style={styles.hr} />
+                        <TouchableOpacity
+                          style={styles.mushroomGridItem}
+                          onPress={() => {
+                            fetchFindingsForMushroom(item.m_id);
+                            setActiveModal(false);
+                          }}
+                        >
+                          <Image
+                            source={mushroomPictureMap[item.mname] || require('../assets/mushroom-photos/mushroom_null.png')}
+                            style={styles.mushroomGridImage}
+                          />
+                          <Text style={styles.mushroomGridName} numberOfLines={2} ellipsizeMode="tail">
+                            {item.cmname}
+                          </Text>
                         </TouchableOpacity>
                       )}
                     />
@@ -647,8 +659,33 @@ const styles = StyleSheet.create({
     alignItems: "center",
     width: 300,
     borderWidth: 5,
-    height: 400,
+    height: 500,
     borderColor: '#D7C5B7',
+  },
+  mushroomGridItem: {
+    width: '45%',
+    padding: 10,
+    alignItems: 'center',
+    margin: 5,
+    borderRadius: 10,
+    borderColor: '#D7C5B7',
+    backgroundColor: '#D7C5B74d',
+    borderWidth: 2,
+    minHeight: 120,
+  },
+  mushroomGridImage: {
+    width: 70,
+    height: 70,
+    resizeMode: 'contain',
+    marginBottom: 5,
+  },
+  mushroomGridName: {
+    fontSize: 13,
+    textAlign: 'center',
+    marginTop: 5,
+    fontFamily: 'Nunito-Bold',
+    color: '#574E47',
+    width: '100%',
   },
   selectFindingmodalContent: {
     backgroundColor: "white",


### PR DESCRIPTION
This pull request enhances the `ChatScreen` in several ways, including improving the UI for selecting mushrooms, adding a grid layout for mushroom options, and introducing new styles for better visual consistency. Below is a summary of the most important changes:

### UI Enhancements for Mushroom Selection:

* Updated the `Image` component in the mushroom selection modal to include `resizeMode: 'contain'` for better image scaling.
* Added a grid layout for displaying mushrooms using `FlatList` with `numColumns={2}` and a new `mushroomGridItem` style for better organization and usability.

### Visual Improvements:

* Introduced new styles for the grid layout, including `mushroomGridItem`, `mushroomGridImage`, and `mushroomGridName`, to enhance the appearance of mushroom items. These styles include padding, border radius, background color, and text styling.
* Increased the modal height from 400 to 500 and added a border color for improved aesthetics.

### Functional Enhancements:

* Added `mushroomPictureMap` to map mushroom names to corresponding images, with a fallback to a default image if no match is found. [[1]](diffhunk://#diff-fe187ff7af8627e6acdd463be14f78d13eb635c47e7200310a71c111caee7c33R14-R15) [[2]](diffhunk://#diff-fe187ff7af8627e6acdd463be14f78d13eb635c47e7200310a71c111caee7c33L512-R535)