### PR TITLE
Improve layout of mushroom selection grid in ChatScreen

### DIFF
--- a/Screens/ChatScreen.jsx
+++ b/Screens/ChatScreen.jsx
@@ -515,9 +515,11 @@ const ChatScreen = () => {
                     </View>
 
                     <FlatList
+                      style={{ width: '100%' }}
                       data={foundMushrooms}
                       keyExtractor={(item) => item.m_id.toString()}
                       numColumns={2}
+                      columnWrapperStyle={{ justifyContent: foundMushrooms.length === 1 ? 'center' : 'space-between' }}
                       renderItem={({ item }) => (
                         <TouchableOpacity
                           style={styles.mushroomGridItem}


### PR DESCRIPTION
This pull request includes a minor UI improvement to the `ChatScreen` component. The changes enhance the layout of the `FlatList` displaying `foundMushrooms` by ensuring better alignment and responsiveness.

UI improvements in `ChatScreen`:

* [`Screens/ChatScreen.jsx`](diffhunk://#diff-fe187ff7af8627e6acdd463be14f78d13eb635c47e7200310a71c111caee7c33R518-R522): Added a `style` property to ensure the `FlatList` spans the full width of the screen and a `columnWrapperStyle` to center items when there is only one mushroom or distribute them evenly otherwise.